### PR TITLE
Fix hatch wheel build excluding package source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,4 @@ testpaths = ["tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
 
 [tool.hatch.build.targets.wheel]
-include = ["oa/data/**/*"]
+packages = ["oa"]


### PR DESCRIPTION
The `[tool.hatch.build.targets.wheel]` table used `include =
["oa/data/**/*"]`. In hatchling, `include` replaces the target's default
file selection rather than adding to it, so wheels (and editable
installs) shipped only the data files and none of the `oa/*.py` source.

Use `packages = ["oa"]` instead: hatch ships every file inside a declared
package directory, so the data files are still included.

Closes #12
