### PR TITLE
Make infer_schema_from_verbal_description backend-injectable

### DIFF
--- a/oa/tests/test_tools.py
+++ b/oa/tests/test_tools.py
@@ -1,0 +1,73 @@
+"""Tests for oa.tools — focused on the injectable LLM backend.
+
+These exercise prompt-function composition with a *fake* ``prompt_func`` so they
+run offline (no provider call), verifying that the backend is genuinely
+injectable (not hardwired to OpenAI).
+"""
+
+import json
+
+from oa.tools import (
+    prompt_function,
+    prompt_json_function,
+    infer_schema_from_verbal_description,
+)
+
+
+def test_prompt_function_uses_injected_backend():
+    calls = []
+
+    def fake_llm(prompt, **kwargs):
+        calls.append((prompt, kwargs))
+        return "FAKE:" + prompt
+
+    f = prompt_function("Say hi to {name}", prompt_func=fake_llm)
+    out = f(name="Ada")
+    assert out == "FAKE:Say hi to Ada"
+    assert calls and "Ada" in calls[0][0]
+
+
+def test_prompt_json_function_uses_injected_backend():
+    captured = {}
+
+    def fake_llm(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured["kwargs"] = kwargs
+        return json.dumps({"answer": 42})
+
+    f = prompt_json_function(
+        "Answer about {topic}",
+        {"name": "ans", "schema": {"properties": {"answer": {"type": "integer"}}}},
+        prompt_func=fake_llm,
+        model=None,  # let the backend resolve its own default
+    )
+    result = f(topic="life")
+    assert result == {"answer": 42}
+    # the schema is forwarded as response_format, and model is threaded through
+    assert captured["kwargs"]["response_format"]["type"] == "json_schema"
+    assert "model" in captured["kwargs"]
+
+
+def test_infer_schema_backend_is_injectable():
+    """The named NL→schema helper must route through an injected backend (not OpenAI)."""
+    seen = {}
+
+    def fake_llm(prompt, **kwargs):
+        seen["model"] = kwargs.get("model")
+        return json.dumps(
+            {
+                "name": "person",
+                "properties": {"age": {"type": "integer"}},
+                "type": "object",
+            }
+        )
+
+    schema = infer_schema_from_verbal_description(
+        "an object with an integer age",
+        prompt_func=fake_llm,
+        model=None,
+    )
+    assert schema["name"] == "person"
+    assert schema["properties"]["age"]["type"] == "integer"
+    # model=None was threaded through verbatim (backend resolves its own default)
+    assert seen["model"] is None

--- a/oa/tools.py
+++ b/oa/tools.py
@@ -516,13 +516,40 @@ def prompt_json_function(
     return func
 
 
-def infer_schema_from_verbal_description(verbal_description: str):
+def infer_schema_from_verbal_description(
+    verbal_description: str,
+    *,
+    prompt_func=chat,
+    prompt_func_kwargs=None,
+    model="gpt-4o-mini",
+):
+    """Infer a JSON Schema (``{name, properties, type}``) from a verbal description.
+
+    The LLM backend is **injectable** so this is not hardwired to OpenAI: pass any
+    ``prompt_func`` with the ``(prompt, **kwargs) -> str`` shape (e.g. a
+    provider-agnostic ``aix.chat``) to route the inference through a different
+    provider, optionally pinning ``model`` / extra ``prompt_func_kwargs``. The
+    defaults preserve the original behavior (oa's ``chat`` on ``gpt-4o-mini``).
+
+    Args:
+        verbal_description: Natural-language description of the desired JSON output.
+        prompt_func: The LLM callable to use (default: oa's ``chat``). Forwarded to
+            :func:`prompt_json_function`.
+        prompt_func_kwargs: Extra keyword arguments merged into the ``prompt_func``
+            call (e.g. provider options).
+        model: Model id passed to ``prompt_func`` (pass ``None`` to let an
+            ``aix``-style backend resolve its own configured default).
+
+    Returns:
+        A ``dict`` with at least ``name`` and ``properties`` keys (the inferred
+        JSON Schema, formatted for OpenAI "JSON mode").
+    """
     template = """
-    Generate a valid JSON Schema based on the the verbal description of the desired 
-    JSON output below. 
-    The schema must be properly formatted for use with OpenAI’s Chat API 
-    in "JSON mode" and should accurately define the structure, 
-    data types, required fields, and any constraints specified by the user. 
+    Generate a valid JSON Schema based on the the verbal description of the desired
+    JSON output below.
+    The schema must be properly formatted for use with OpenAI’s Chat API
+    in "JSON mode" and should accurately define the structure,
+    data types, required fields, and any constraints specified by the user.
     Ensure correctness and completeness.
 
     Note that you need to provide not only a valid schema but also a valid name for it.
@@ -541,7 +568,13 @@ def infer_schema_from_verbal_description(verbal_description: str):
             "required": ["name", "properties"],
         },
     }
-    f = prompt_json_function(template, output_schema)
+    f = prompt_json_function(
+        template,
+        output_schema,
+        prompt_func=prompt_func,
+        prompt_func_kwargs=prompt_func_kwargs,
+        model=model,
+    )
     return f(verbal_description=verbal_description)
 
 


### PR DESCRIPTION
## What

`oa.infer_schema_from_verbal_description` was hardwired to oa's OpenAI `chat`. This threads an injectable `prompt_func` / `prompt_func_kwargs` / `model` through to the underlying `prompt_json_function`, so the NL→schema inference can run on **any** provider-agnostic backend (e.g. `aix.chat`).

## Why

First customer is **coact**'s new *NL-description → IntegrationSpec* ingress, which routes LLM generation through `aix` (multi-provider) rather than oa's OpenAI default. The function being un-injectable was a real limitation.

## Compatibility

Fully backward-compatible — defaults (`prompt_func=chat`, `model='gpt-4o-mini'`) preserve the original behavior. Added a docstring (it had none) and offline tests using a fake backend (no provider call).

## Tests

`oa/tests/test_tools.py` — 3 new offline tests; full `oa/tests` suite green; ruff clean.